### PR TITLE
Specify that return is Base64 Encoded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The code was extracted directly from Chromium examples for extensions.
 
 ``` js
 var hmacsha1 = require('hmacsha1');
-var hash = hmacsha1(KEY, DATA);
+var hash = hmacsha1(KEY, DATA);  //Returns Base64 Encoded String
 ```
 
 ## Link


### PR DESCRIPTION
Allows the user of the npm module to know that the returned string is Base64 encoded. There was no mention of this.
